### PR TITLE
Add rebar.config

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,0 +1,5 @@
+{erl_opts,
+ [debug_info,
+  warn_unused_vars,
+  warn_shadow_vars,
+  warn_unused_import]}.


### PR DESCRIPTION
This patch adds a `rebar.config` to the top-level directory. `rebar`
will pick this file up when called from the `Makefile`. The file includes
`erl_opts` passed to the compiler. These options will help clean up the
code and catch mistakes.

See http://erlang.org/doc/man/compile.html for more info on the options.
